### PR TITLE
Remove miscellaneous backtick

### DIFF
--- a/source/index.pug
+++ b/source/index.pug
@@ -20,7 +20,7 @@ body
     each cursor in cursors
       li(class=`${cursor.name}` data-css=`cursor:${cursor.name};` style=`cursor: ${cursor.name};`)
         img(src=`${cursor.img}`, alt=`${cursor.name}`)
-        p #{cursor.name}`
+        p #{cursor.name}
 
     li.deets
       p Made with love By Wes Bos


### PR DESCRIPTION
Hey 👋  even after all these years I still find myself referencing this, so thanks.

I noticed there was a backtick after all the names...
![image](https://user-images.githubusercontent.com/9257284/111327510-5c1aa100-8665-11eb-826d-159cc71a51e0.png)

I don't know pug, and haven't tested this, but I've made a guess at what the extra backtick is and deleted it. Hope it's the right one. 🤞 